### PR TITLE
Added String URL helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Note the original client side Swift 2 repo can be found here:
 
 ## This Fork
 
-This fork is intended as a server side utility. 
+This fork is intended as a server side utility.
 
 * It is Swift 3.0 and Swift Package Manager (SPM) ready.
-* Added sigificant test coverage 
+* Added sigificant test coverage
 
 
 ## Usage
@@ -70,6 +70,19 @@ import SwiftString
 "foobar".chompRight("foo") // "bar"
 ```
 
+**cleanPath()**
+
+```swift
+var foo = "hello//world/..///stuff.txt"
+foo.cleanPath() // foo == "hello/stuff.txt"
+```
+
+**cleanedPath()**
+
+```swift
+"hello//world/..///stuff.txt".cleanedPath() // "hello/stuff.txt"
+```
+
 **collapseWhitespace()**
 
 ```swift
@@ -109,6 +122,36 @@ import SwiftString
 ```swift
 "subdir/".ensureRight("/") // "subdir/"
 "subdir".ensureRight("/") // "subdir/"
+```
+
+**extension**
+
+```swift
+"/hello/world.txt".extension // "txt"
+"/hello/world.tmp.txt".extension // "txt"
+```
+
+**file**
+
+```swift
+"/hello/world.txt".file // "world.txt"
+"/hello/there/".file // "there"
+```
+
+**fileName**
+
+```swift
+"/hello/world.txt".fileName // "world"
+"/hello/there/".fileName // "there"
+```
+
+**index(of: substring)**
+
+```swift
+"hello".index(of: "hell"), // 0
+"hello".index(of: "lo"), // 3
+"hello".index(of: "world") // -1
+"hellohello".index(of: "hel", after: 2) // 5
 ```
 
 **indexOf(substring)**
@@ -173,6 +216,32 @@ import SwiftString
 "-63.0".isNumeric() // true
 ```
 
+**join(paths...)**
+
+```swift
+var root = "/foo"
+root.join("bar", "/baz", "..", "//somedata.txt") // root == "/foo/bar/somedata.txt"
+
+var root = "/foo"
+root.join(paths: ["bar", "/baz", "..", "//somedata.txt"]) // root == "/foo/bar/somedata.txt"
+```
+
+**joining(paths...)**
+
+```swift
+"/foo".joining("bar", "/baz", "..", "//somedata.txt") // "/foo/bar/somedata.txt"
+"/foo".joining(paths: ["bar", "/baz", "..", "//somedata.txt"]) // "/foo/bar/somedata.txt"
+```
+
+**lastIndex(of: substring)**
+
+```swift
+"hellohellohello".lastIndex(of: "hell"), // 10
+"hellohellohello".lastIndex(of: "lo"), // 13
+"hellohellohello".lastIndex(of: "world") // -1
+"hellohellohello".index(of: "hel", before: 10) // 5
+```
+
 **latinize()**
 
 ```swift
@@ -207,6 +276,13 @@ import SwiftString
 ```swift
 "hello".padRight(10) // "hello          "
 "hello".padRight(2, "!") // "hello!!"
+```
+
+**parent**
+
+```swift
+"/hello/there/world.txt".parent // "/hello/there"
+"/hello/there".parent // "/hello"
 ```
 
 **startsWith(prefix)**
@@ -336,7 +412,7 @@ import SwiftString
 
 ``` swift
 .Package(
-    url: "https://github.com/iamjono/SwiftString.git", 
+    url: "https://github.com/iamjono/SwiftString.git",
     majorVersion: 1, minor: 0
     ),
 ```

--- a/Sources/StringURL.swift
+++ b/Sources/StringURL.swift
@@ -1,0 +1,125 @@
+//
+//  StringHTTP.swift
+//  SwiftString
+//
+//  Created by thislooksfun on 1/3/17.
+//
+//
+
+import Foundation
+
+private let parentBacktrackRegex = try! NSRegularExpression(pattern: "([^/]*)?\\/+\\.\\.", options: [])
+extension String {
+	/// The parent directory or url
+	/// i.e. calling `"/foo/bar/baz".parent` will return `"/foo/bar"`
+	public var parent: String? {
+		var ref = self
+		if self.lastIndex(of: "/") == self.length - 1 {
+			ref = self[0..<self.length - 1]
+		}
+		
+		let index = ref.lastIndex(of: "/")
+		if index > -1 {
+			return ref[0..<index]
+		}
+		return nil
+	}
+	/// The full file or directory name and extension
+	/// i.e. calling `"/foo/bar/baz.txt".file` will return `"baz.txt"`
+	public var file: String? {
+		var ref = self
+		if self.lastIndex(of: "/") == self.length - 1 {
+			ref = self[0..<self.length - 1]
+		}
+		
+		let index = ref.lastIndex(of: "/")
+		if index > -1 {
+			print(index, self.length)
+			return ref[index+1..<ref.length]
+		}
+		return nil
+	}
+	/// The file or directory name without extension
+	/// i.e. calling `"/foo/bar/baz.txt".file` will return `"baz"`
+	public var fileName: String? {
+		guard let f = file else {
+			return nil
+		}
+		
+		let index = f.lastIndex(of: ".")
+		if index > -1 {
+			return f[0..<index]
+		}
+		return file
+	}
+	/// The file or directory extension
+	/// i.e. calling `"/foo/bar/baz.txt".file` will return `"txt"`
+	public var `extension`: String? {
+		guard let f = file else {
+			return nil
+		}
+		
+		let index = f.lastIndex(of: ".")
+		if index > -1 {
+			return f[index+1..<f.length]
+		}
+		return nil
+	}
+	
+	/// The file path, but removing all double slashes (//) and resolving 'back' paths (..)
+	/// i.e. calling `cleanPath` on `"/foo///bar/baz/../thing.txt"` would result in `"/foo/bar/thing.txt"`
+	public mutating func cleanPath() {
+		self = cleanedPath()
+	}
+	/// The file path, but removing all double slashes (//) and resolving 'back' paths (..)
+	/// i.e. calling `"/foo///bar/baz/../thing.txt".cleanedPath()` would return `"/foo/bar/thing.txt"`
+	public func cleanedPath() -> String {
+		// Remove duplicate slashes
+		var str = self
+		while str.contains("//") {
+			str = str.replacingOccurrences(of: "//", with: "/")
+		}
+		// Parse `..`s
+		while let match = parentBacktrackRegex.firstMatch(in: str, options: [], range: NSMakeRange(0, str.length)) {
+			let min = str.index(str.startIndex, offsetBy: match.range.location)
+			let max = str.index(str.startIndex, offsetBy: match.range.location + match.range.length)
+			str.removeSubrange(min..<max)
+			
+			while str.contains("//") {
+				str = str.replacingOccurrences(of: "//", with: "/")
+			}
+		}
+		return str
+	}
+	
+	/// Join a series of paths together with this as the base
+	/// i.e. calling `"/foo".join("bar/", "../baz.txt")` will result in `"/foo/baz.txt"`
+	/// Note: This calls `cleanPath()`, so there is no need to do that yourself
+	public mutating func join(_ paths: String...) {
+		join(paths: paths)
+	}
+	/// Join an array of paths together with this as the base
+	/// i.e. calling `"/foo".join(paths: ["bar/", "../baz.txt"])` will result in `"/foo/baz.txt"`
+	/// Note: This calls `cleanPath()`, so there is no need to do that yourself
+	public mutating func join(paths: [String]) {
+		for path in paths {
+			self += "/\(path)"
+		}
+		self.cleanPath()
+	}
+	
+	/// Join a series of paths together with this as the base, and return it
+	/// i.e. calling `"/foo".joining("bar/", "../baz.txt")` will return `"/foo/baz.txt"`
+	/// Note: This calls `cleanPath()`, so there is no need to do that yourself
+	public func joining(_ paths: String...) -> String {
+		return joining(paths: paths)
+	}
+	/// Join an array of paths together with this as the base, and return it
+	/// i.e. calling `"/foo".joining(paths: ["bar/", "../baz.txt"])` will return `"/foo/baz.txt"`
+	/// Note: This calls `cleanPath()`, so there is no need to do that yourself
+	public func joining(paths: [String]) -> String {
+		var tmp = self
+		tmp.join(paths: paths)
+		return tmp
+	}
+}

--- a/SwiftString.xcodeproj/project.pbxproj
+++ b/SwiftString.xcodeproj/project.pbxproj
@@ -7,133 +7,119 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		_LinkFileRef_SwiftString_via_SwiftStringTests /* SwiftString.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_SwiftString" /* SwiftString.framework */; };
-		"__src_cc_ref_Sources/String+HTML.swift" /* StringHTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Sources/String+HTML.swift" /* StringHTML.swift */; };
-		__src_cc_ref_Sources/StringExtensions.swift /* StringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/StringExtensions.swift /* StringExtensions.swift */; };
-		__src_cc_ref_Tests/SwiftStringTests/SwiftStringTests.swift /* SwiftStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Tests/SwiftStringTests/SwiftStringTests.swift /* SwiftStringTests.swift */; };
+		F40014791E1C823400AF13BE /* StringURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = F40014781E1C823400AF13BE /* StringURL.swift */; };
+		F400147C1E1C8C2B00AF13BE /* StringURLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F400147A1E1C8B5D00AF13BE /* StringURLTests.swift */; };
+		OBJ_22 /* StringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_9 /* StringExtensions.swift */; };
+		OBJ_23 /* StringHTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_10 /* StringHTML.swift */; };
+		OBJ_30 /* SwiftStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_13 /* SwiftStringTests.swift */; };
+		OBJ_32 /* SwiftString.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = OBJ_15 /* SwiftString.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		E0AD59D81D91B4DD00DC93F0 /* PBXContainerItemProxy */ = {
+		F40014771E1C820D00AF13BE /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = __RootObject_ /* Project object */;
+			containerPortal = OBJ_1 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = "______Target_SwiftString";
+			remoteGlobalIDString = OBJ_17;
 			remoteInfo = SwiftString;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		__PBXFileRef_Package.swift /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Sources/String+HTML.swift" /* StringHTML.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = StringHTML.swift; path = Sources/StringHTML.swift; sourceTree = "<group>"; };
-		__PBXFileRef_Sources/StringExtensions.swift /* StringExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = StringExtensions.swift; path = Sources/StringExtensions.swift; sourceTree = "<group>"; };
-		__PBXFileRef_SwiftString.xcodeproj/Configs/Debug.xcconfig /* SwiftString.xcodeproj/Configs/Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = SwiftString.xcodeproj/Configs/Debug.xcconfig; sourceTree = "<group>"; };
-		__PBXFileRef_SwiftString.xcodeproj/Configs/Project.xcconfig /* SwiftString.xcodeproj/Configs/Project.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = SwiftString.xcodeproj/Configs/Project.xcconfig; sourceTree = "<group>"; };
-		__PBXFileRef_SwiftString.xcodeproj/Configs/Release.xcconfig /* SwiftString.xcodeproj/Configs/Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = SwiftString.xcodeproj/Configs/Release.xcconfig; sourceTree = "<group>"; };
-		__PBXFileRef_Tests/SwiftStringTests/SwiftStringTests.swift /* SwiftStringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SwiftStringTests.swift; path = Tests/SwiftStringTests/SwiftStringTests.swift; sourceTree = "<group>"; };
-		"_____Product_SwiftString" /* SwiftString.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = SwiftString.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		"_____Product_SwiftStringTests" /* SwiftStringTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; path = SwiftStringTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		F40014781E1C823400AF13BE /* StringURL.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringURL.swift; sourceTree = "<group>"; };
+		F400147A1E1C8B5D00AF13BE /* StringURLTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringURLTests.swift; sourceTree = "<group>"; };
+		OBJ_10 /* StringHTML.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringHTML.swift; sourceTree = "<group>"; };
+		OBJ_13 /* SwiftStringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftStringTests.swift; sourceTree = "<group>"; };
+		OBJ_15 /* SwiftString.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = SwiftString.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		OBJ_16 /* SwiftStringTests.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; path = SwiftStringTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
+		OBJ_9 /* StringExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensions.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		"___LinkPhase_SwiftString" /* Frameworks */ = {
+		OBJ_24 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		"___LinkPhase_SwiftStringTests" /* Frameworks */ = {
+		OBJ_31 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				_LinkFileRef_SwiftString_via_SwiftStringTests /* SwiftString.framework in Frameworks */,
+				OBJ_32 /* SwiftString.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		TestProducts_ /* Tests */ = {
+		OBJ_11 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				"_____Product_SwiftStringTests" /* SwiftStringTests.xctest */,
+				OBJ_12 /* SwiftStringTests */,
 			);
-			name = Tests;
+			path = Tests;
 			sourceTree = "<group>";
 		};
-		"___RootGroup_" = {
+		OBJ_12 /* SwiftStringTests */ = {
 			isa = PBXGroup;
 			children = (
-				__PBXFileRef_Package.swift /* Package.swift */,
-				"_____Configs_" /* Configs */,
-				"_____Sources_" /* Sources */,
-				"_______Tests_" /* Tests */,
-				"____Products_" /* Products */,
-			);
-			sourceTree = "<group>";
-		};
-		"____Products_" /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				TestProducts_ /* Tests */,
-				"_____Product_SwiftString" /* SwiftString.framework */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		"_____Configs_" /* Configs */ = {
-			isa = PBXGroup;
-			children = (
-				__PBXFileRef_SwiftString.xcodeproj/Configs/Project.xcconfig /* SwiftString.xcodeproj/Configs/Project.xcconfig */,
-				__PBXFileRef_SwiftString.xcodeproj/Configs/Debug.xcconfig /* SwiftString.xcodeproj/Configs/Debug.xcconfig */,
-				__PBXFileRef_SwiftString.xcodeproj/Configs/Release.xcconfig /* SwiftString.xcodeproj/Configs/Release.xcconfig */,
-			);
-			name = Configs;
-			sourceTree = "<group>";
-		};
-		"_____Sources_" /* Sources */ = {
-			isa = PBXGroup;
-			children = (
-				"_______Group_SwiftString" /* SwiftString */,
-			);
-			name = Sources;
-			sourceTree = "<group>";
-		};
-		"_______Group_SwiftString" /* SwiftString */ = {
-			isa = PBXGroup;
-			children = (
-				"__PBXFileRef_Sources/String+HTML.swift" /* StringHTML.swift */,
-				__PBXFileRef_Sources/StringExtensions.swift /* StringExtensions.swift */,
-			);
-			name = SwiftString;
-			sourceTree = "<group>";
-		};
-		"_______Group_SwiftStringTests" /* SwiftStringTests */ = {
-			isa = PBXGroup;
-			children = (
-				__PBXFileRef_Tests/SwiftStringTests/SwiftStringTests.swift /* SwiftStringTests.swift */,
+				OBJ_13 /* SwiftStringTests.swift */,
+				F400147A1E1C8B5D00AF13BE /* StringURLTests.swift */,
 			);
 			name = SwiftStringTests;
-			sourceTree = "<group>";
+			path = Tests/SwiftStringTests;
+			sourceTree = SOURCE_ROOT;
 		};
-		"_______Tests_" /* Tests */ = {
+		OBJ_14 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				"_______Group_SwiftStringTests" /* SwiftStringTests */,
+				OBJ_15 /* SwiftString.framework */,
+				OBJ_16 /* SwiftStringTests.xctest */,
 			);
-			name = Tests;
+			name = Products;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		OBJ_5 = {
+			isa = PBXGroup;
+			children = (
+				OBJ_6 /* Package.swift */,
+				OBJ_7 /* Sources */,
+				OBJ_11 /* Tests */,
+				OBJ_14 /* Products */,
+			);
 			sourceTree = "<group>";
+		};
+		OBJ_7 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_8 /* SwiftString */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
+		OBJ_8 /* SwiftString */ = {
+			isa = PBXGroup;
+			children = (
+				OBJ_9 /* StringExtensions.swift */,
+				OBJ_10 /* StringHTML.swift */,
+				F40014781E1C823400AF13BE /* StringURL.swift */,
+			);
+			name = SwiftString;
+			path = Sources;
+			sourceTree = SOURCE_ROOT;
 		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		"______Target_SwiftString" /* SwiftString */ = {
+		OBJ_17 /* SwiftString */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = "_______Confs_SwiftString" /* Build configuration list for PBXNativeTarget "SwiftString" */;
+			buildConfigurationList = OBJ_18 /* Build configuration list for PBXNativeTarget "SwiftString" */;
 			buildPhases = (
-				CompilePhase_SwiftString /* Sources */,
-				"___LinkPhase_SwiftString" /* Frameworks */,
+				OBJ_21 /* Sources */,
+				OBJ_24 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -141,200 +127,230 @@
 			);
 			name = SwiftString;
 			productName = SwiftString;
-			productReference = "_____Product_SwiftString" /* SwiftString.framework */;
+			productReference = OBJ_15 /* SwiftString.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		"______Target_SwiftStringTests" /* SwiftStringTests */ = {
+		OBJ_25 /* SwiftStringTests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = "_______Confs_SwiftStringTests" /* Build configuration list for PBXNativeTarget "SwiftStringTests" */;
+			buildConfigurationList = OBJ_26 /* Build configuration list for PBXNativeTarget "SwiftStringTests" */;
 			buildPhases = (
-				CompilePhase_SwiftStringTests /* Sources */,
-				"___LinkPhase_SwiftStringTests" /* Frameworks */,
+				OBJ_29 /* Sources */,
+				OBJ_31 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				__Dependency_SwiftString /* PBXTargetDependency */,
+				OBJ_33 /* PBXTargetDependency */,
 			);
 			name = SwiftStringTests;
 			productName = SwiftStringTests;
-			productReference = "_____Product_SwiftStringTests" /* SwiftStringTests.xctest */;
+			productReference = OBJ_16 /* SwiftStringTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		__RootObject_ /* Project object */ = {
+		OBJ_1 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				LastUpgradeCheck = 9999;
-				TargetAttributes = {
-					"______Target_SwiftString" = {
-						LastSwiftMigration = 0800;
-					};
-					"______Target_SwiftStringTests" = {
-						LastSwiftMigration = 0800;
-					};
-				};
 			};
-			buildConfigurationList = "___RootConfs_" /* Build configuration list for PBXProject "SwiftString" */;
+			buildConfigurationList = OBJ_2 /* Build configuration list for PBXProject "SwiftString" */;
 			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
 			);
-			mainGroup = "___RootGroup_";
-			productRefGroup = "____Products_" /* Products */;
+			mainGroup = OBJ_5;
+			productRefGroup = OBJ_14 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				"______Target_SwiftString" /* SwiftString */,
-				"______Target_SwiftStringTests" /* SwiftStringTests */,
+				OBJ_17 /* SwiftString */,
+				OBJ_25 /* SwiftStringTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXSourcesBuildPhase section */
-		CompilePhase_SwiftString /* Sources */ = {
+		OBJ_21 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				"__src_cc_ref_Sources/String+HTML.swift" /* StringHTML.swift in Sources */,
-				__src_cc_ref_Sources/StringExtensions.swift /* StringExtensions.swift in Sources */,
+				F40014791E1C823400AF13BE /* StringURL.swift in Sources */,
+				OBJ_22 /* StringExtensions.swift in Sources */,
+				OBJ_23 /* StringHTML.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		CompilePhase_SwiftStringTests /* Sources */ = {
+		OBJ_29 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				__src_cc_ref_Tests/SwiftStringTests/SwiftStringTests.swift /* SwiftStringTests.swift in Sources */,
+				F400147C1E1C8C2B00AF13BE /* StringURLTests.swift in Sources */,
+				OBJ_30 /* SwiftStringTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		__Dependency_SwiftString /* PBXTargetDependency */ = {
+		OBJ_33 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = "______Target_SwiftString" /* SwiftString */;
-			targetProxy = E0AD59D81D91B4DD00DC93F0 /* PBXContainerItemProxy */;
+			target = OBJ_17 /* SwiftString */;
+			targetProxy = F40014771E1C820D00AF13BE /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		_ReleaseConf_SwiftString /* Release */ = {
+		OBJ_19 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = SwiftString.xcodeproj/SwiftString_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "\"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx\"";
-				LIBRARY_SEARCH_PATHS = "\"$(PROJECT_TEMP_DIR)/SymlinkLibs/\"";
-				OTHER_LDFLAGS = "\"$(inherited)\"";
-				OTHER_SWIFT_FLAGS = "\"$(inherited)\"";
+				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = SwiftString;
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
-				SWIFT_VERSION = 3.0;
+				TARGET_NAME = SwiftString;
 			};
-			name = Release;
+			name = Debug;
 		};
-		_ReleaseConf_SwiftStringTests /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
-				INFOPLIST_FILE = SwiftString.xcodeproj/SwiftStringTests_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks";
-				LIBRARY_SEARCH_PATHS = "\"$(PROJECT_TEMP_DIR)/SymlinkLibs/\"";
-				OTHER_LDFLAGS = "\"$(inherited)\"";
-				OTHER_SWIFT_FLAGS = "\"$(inherited)\"";
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
-				SWIFT_VERSION = 3.0;
-			};
-			name = Release;
-		};
-		"___DebugConf_SwiftString" /* Debug */ = {
+		OBJ_20 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ENABLE_TESTABILITY = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = SwiftString.xcodeproj/SwiftString_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "\"$(TOOLCHAIN_DIR)/usr/lib/swift/macosx\"";
-				LIBRARY_SEARCH_PATHS = "\"$(PROJECT_TEMP_DIR)/SymlinkLibs/\"";
-				OTHER_LDFLAGS = "\"$(inherited)\"";
-				OTHER_SWIFT_FLAGS = "\"$(inherited)\"";
+				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = SwiftString;
 				PRODUCT_MODULE_NAME = "$(TARGET_NAME:c99extidentifier)";
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
-				SWIFT_VERSION = 3.0;
-			};
-			name = Debug;
-		};
-		"___DebugConf_SwiftStringTests" /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
-				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
-				INFOPLIST_FILE = SwiftString.xcodeproj/SwiftStringTests_Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks";
-				LIBRARY_SEARCH_PATHS = "\"$(PROJECT_TEMP_DIR)/SymlinkLibs/\"";
-				OTHER_LDFLAGS = "\"$(inherited)\"";
-				OTHER_SWIFT_FLAGS = "\"$(inherited)\"";
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
-				SWIFT_VERSION = 3.0;
-			};
-			name = Debug;
-		};
-		"_____Release_" /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = __PBXFileRef_SwiftString.xcodeproj/Configs/Release.xcconfig /* SwiftString.xcodeproj/Configs/Release.xcconfig */;
-			buildSettings = {
+				TARGET_NAME = SwiftString;
 			};
 			name = Release;
 		};
-		"_______Debug_" /* Debug */ = {
+		OBJ_27 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = __PBXFileRef_SwiftString.xcodeproj/Configs/Debug.xcconfig /* SwiftString.xcodeproj/Configs/Debug.xcconfig */;
 			buildSettings = {
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = SwiftString.xcodeproj/SwiftStringTests_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				TARGET_NAME = SwiftStringTests;
 			};
 			name = Debug;
+		};
+		OBJ_28 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				EMBEDDED_CONTENT_CONTAINS_SWIFT = YES;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
+				INFOPLIST_FILE = SwiftString.xcodeproj/SwiftStringTests_Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "@loader_path/../Frameworks";
+				OTHER_LDFLAGS = "$(inherited)";
+				OTHER_SWIFT_FLAGS = "$(inherited)";
+				TARGET_NAME = SwiftStringTests;
+			};
+			name = Release;
+		};
+		OBJ_3 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_NS_ASSERTIONS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_SWIFT_FLAGS = "-DXcode";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
+				USE_HEADERMAP = NO;
+			};
+			name = Debug;
+		};
+		OBJ_4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_OPTIMIZATION_LEVEL = s;
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_SWIFT_FLAGS = "-DXcode";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+				SUPPORTED_PLATFORMS = "macosx iphoneos iphonesimulator appletvos appletvsimulator watchos watchsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = SWIFT_PACKAGE;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 3.0;
+				USE_HEADERMAP = NO;
+			};
+			name = Release;
 		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		"___RootConfs_" /* Build configuration list for PBXProject "SwiftString" */ = {
+		OBJ_18 /* Build configuration list for PBXNativeTarget "SwiftString" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				"_______Debug_" /* Debug */,
-				"_____Release_" /* Release */,
+				OBJ_19 /* Debug */,
+				OBJ_20 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		"_______Confs_SwiftString" /* Build configuration list for PBXNativeTarget "SwiftString" */ = {
+		OBJ_2 /* Build configuration list for PBXProject "SwiftString" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				"___DebugConf_SwiftString" /* Debug */,
-				_ReleaseConf_SwiftString /* Release */,
+				OBJ_3 /* Debug */,
+				OBJ_4 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		"_______Confs_SwiftStringTests" /* Build configuration list for PBXNativeTarget "SwiftStringTests" */ = {
+		OBJ_26 /* Build configuration list for PBXNativeTarget "SwiftStringTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				"___DebugConf_SwiftStringTests" /* Debug */,
-				_ReleaseConf_SwiftStringTests /* Release */,
+				OBJ_27 /* Debug */,
+				OBJ_28 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = __RootObject_ /* Project object */;
+	rootObject = OBJ_1 /* Project object */;
 }

--- a/SwiftString.xcodeproj/xcshareddata/xcschemes/SwiftString.xcscheme
+++ b/SwiftString.xcodeproj/xcshareddata/xcschemes/SwiftString.xcscheme
@@ -14,7 +14,7 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "______Target_SwiftString"
+               BlueprintIdentifier = "OBJ_17"
                BuildableName = "SwiftString.framework"
                BlueprintName = "SwiftString"
                ReferencedContainer = "container:SwiftString.xcodeproj">
@@ -32,7 +32,7 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "______Target_SwiftStringTests"
+               BlueprintIdentifier = "OBJ_25"
                BuildableName = "SwiftStringTests.xctest"
                BlueprintName = "SwiftStringTests"
                ReferencedContainer = "container:SwiftString.xcodeproj">
@@ -55,7 +55,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "______Target_SwiftString"
+            BlueprintIdentifier = "OBJ_17"
             BuildableName = "SwiftString.framework"
             BlueprintName = "SwiftString"
             ReferencedContainer = "container:SwiftString.xcodeproj">

--- a/Tests/SwiftStringTests/StringURLTests.swift
+++ b/Tests/SwiftStringTests/StringURLTests.swift
@@ -1,0 +1,222 @@
+//
+//  StringURLTests.swift
+//  SwiftString
+//
+//  Created by thislooksfun on 1/3/17.
+//
+//
+
+import XCTest
+
+@testable import SwiftString
+
+class StringURLTests: XCTestCase {
+	
+	let rootPathToDir =         "/foo/bar/baz/"
+	let rootPathToDirNoTrail =  "/foo/bar/baz"
+	let rootPathToFile =        "/foo/bar/baz.txt"
+	let rootPathSingleLetters = "/f/b/z"
+	
+	let relPathToDir =         "foo/bar/baz/"
+	let relPathToDirNoTrail =  "foo/bar/baz"
+	let relPathToFile =        "foo/bar/baz.txt"
+	let relPathSingleLetters = "f/b/z"
+	
+	let randomString = "Quick brown fox, or something."
+	
+	func testParent() {
+		let resultRootPathToDir = rootPathToDir.parent
+		XCTAssertNotNil(resultRootPathToDir)
+		XCTAssertEqual(resultRootPathToDir, "/foo/bar")
+		
+		let resultRootPathToDirNoTrail = rootPathToDirNoTrail.parent
+		XCTAssertNotNil(resultRootPathToDirNoTrail)
+		XCTAssertEqual(resultRootPathToDirNoTrail, "/foo/bar")
+		
+		let resultRootPathToFile = rootPathToFile.parent
+		XCTAssertNotNil(resultRootPathToFile)
+		XCTAssertEqual(resultRootPathToFile, "/foo/bar")
+		
+		let resultRootPathSingleLetters = rootPathSingleLetters.parent
+		XCTAssertNotNil(resultRootPathSingleLetters)
+		XCTAssertEqual(resultRootPathSingleLetters, "/f/b")
+		
+		let resultRelPathToDir = relPathToDir.parent
+		XCTAssertNotNil(resultRelPathToDir)
+		XCTAssertEqual(resultRelPathToDir, "foo/bar")
+		
+		let resultRelPathToDirNoTrail = relPathToDirNoTrail.parent
+		XCTAssertNotNil(resultRelPathToDirNoTrail)
+		XCTAssertEqual(resultRelPathToDirNoTrail, "foo/bar")
+		
+		let resultRelPathToFile = relPathToFile.parent
+		XCTAssertNotNil(resultRelPathToFile)
+		XCTAssertEqual(resultRelPathToFile, "foo/bar")
+		
+		let resultRelPathSingleLetters = relPathSingleLetters.parent
+		XCTAssertNotNil(resultRelPathSingleLetters)
+		XCTAssertEqual(resultRelPathSingleLetters, "f/b")
+		
+		let resultRandomString = randomString.parent
+		XCTAssertNil(resultRandomString)
+	}
+	
+	func testFile() {
+		let resultRootPathToDir = rootPathToDir.file
+		XCTAssertNotNil(resultRootPathToDir)
+		XCTAssertEqual(resultRootPathToDir, "baz")
+		
+		let resultRootPathToDirNoTrail = rootPathToDirNoTrail.file
+		XCTAssertNotNil(resultRootPathToDirNoTrail)
+		XCTAssertEqual(resultRootPathToDirNoTrail, "baz")
+		
+		let resultRootPathToFile = rootPathToFile.file
+		XCTAssertNotNil(resultRootPathToFile)
+		XCTAssertEqual(resultRootPathToFile, "baz.txt")
+		
+		let resultRootPathSingleLetters = rootPathSingleLetters.file
+		XCTAssertNotNil(resultRootPathSingleLetters)
+		XCTAssertEqual(resultRootPathSingleLetters, "z")
+		
+		let resultRelPathToDir = relPathToDir.file
+		XCTAssertNotNil(resultRelPathToDir)
+		XCTAssertEqual(resultRelPathToDir, "baz")
+		
+		let resultRelPathToDirNoTrail = relPathToDirNoTrail.file
+		XCTAssertNotNil(resultRelPathToDirNoTrail)
+		XCTAssertEqual(resultRelPathToDirNoTrail, "baz")
+		
+		let filetRelPathToFile = relPathToFile.file
+		XCTAssertNotNil(filetRelPathToFile)
+		XCTAssertEqual(filetRelPathToFile, "baz.txt")
+		
+		let resultRelPathSingleLetters = relPathSingleLetters.file
+		XCTAssertNotNil(resultRelPathSingleLetters)
+		XCTAssertEqual(resultRelPathSingleLetters, "z")
+		
+		let resultRandomString = randomString.file
+		XCTAssertNil(resultRandomString)
+	}
+	
+	func testFileName() {
+		let resultRootPathToDir = rootPathToDir.fileName
+		XCTAssertNotNil(resultRootPathToDir)
+		XCTAssertEqual(resultRootPathToDir, "baz")
+		
+		let resultRootPathToDirNoTrail = rootPathToDirNoTrail.fileName
+		XCTAssertNotNil(resultRootPathToDirNoTrail)
+		XCTAssertEqual(resultRootPathToDirNoTrail, "baz")
+		
+		let resultRootPathToFile = rootPathToFile.fileName
+		XCTAssertNotNil(resultRootPathToFile)
+		XCTAssertEqual(resultRootPathToFile, "baz")
+		
+		let resultRootPathSingleLetters = rootPathSingleLetters.fileName
+		XCTAssertNotNil(resultRootPathSingleLetters)
+		XCTAssertEqual(resultRootPathSingleLetters, "z")
+		
+		let resultRelPathToDir = relPathToDir.fileName
+		XCTAssertNotNil(resultRelPathToDir)
+		XCTAssertEqual(resultRelPathToDir, "baz")
+		
+		let resultRelPathToDirNoTrail = relPathToDirNoTrail.fileName
+		XCTAssertNotNil(resultRelPathToDirNoTrail)
+		XCTAssertEqual(resultRelPathToDirNoTrail, "baz")
+		
+		let filetRelPathToFile = relPathToFile.fileName
+		XCTAssertNotNil(filetRelPathToFile)
+		XCTAssertEqual(filetRelPathToFile, "baz")
+		
+		let resultRelPathSingleLetters = relPathSingleLetters.fileName
+		XCTAssertNotNil(resultRelPathSingleLetters)
+		XCTAssertEqual(resultRelPathSingleLetters, "z")
+		
+		let resultRandomString = randomString.fileName
+		XCTAssertNil(resultRandomString)
+	}
+	
+	func testExtension() {
+		let resultRootPathToDir = rootPathToDir.extension
+		XCTAssertNil(resultRootPathToDir)
+		
+		let resultRootPathToDirNoTrail = rootPathToDirNoTrail.extension
+		XCTAssertNil(resultRootPathToDirNoTrail)
+		
+		let resultRootPathToFile = rootPathToFile.extension
+		XCTAssertNotNil(resultRootPathToFile)
+		XCTAssertEqual(resultRootPathToFile, "txt")
+		
+		let resultRootPathSingleLetters = rootPathSingleLetters.extension
+		XCTAssertNil(resultRootPathSingleLetters)
+		
+		let resultRelPathToDir = relPathToDir.extension
+		XCTAssertNil(resultRelPathToDir)
+		
+		let resultRelPathToDirNoTrail = relPathToDirNoTrail.extension
+		XCTAssertNil(resultRelPathToDirNoTrail)
+		
+		let filetRelPathToFile = relPathToFile.extension
+		XCTAssertNotNil(filetRelPathToFile)
+		XCTAssertEqual(filetRelPathToFile, "txt")
+		
+		let resultRelPathSingleLetters = relPathSingleLetters.extension
+		XCTAssertNil(resultRelPathSingleLetters)
+		
+		let resultRandomString = randomString.extension
+		XCTAssertNil(resultRandomString)
+	}
+	
+	func testCleanPath() {
+		var testStringA = "/foo/bar//baz/..////data.txt"
+		testStringA.cleanPath()
+		XCTAssertEqual(testStringA, "/foo/bar/data.txt")
+		
+		var testStringB = "../foo/bar//baz/..///..//data.txt"
+		testStringB.cleanPath()
+		XCTAssertEqual(testStringB, "../foo/data.txt")
+	}
+	
+	func testCleanedPath() {
+		let testStringA = "/foo/bar//baz/..///data.txt"
+		XCTAssertEqual(testStringA.cleanedPath(), "/foo/bar/data.txt")
+		
+		let testStringB = "../foo/bar//baz/..///..//data.txt"
+		XCTAssertEqual(testStringB.cleanedPath(), "../foo/data.txt")
+	}
+	
+	func testJoinVararg() {
+		var base1 = "/foo/bar"
+		base1.join("/baz", "..", "/..//data.txt")
+		XCTAssertEqual(base1, "/foo/data.txt")
+		
+		var base2 = "/foo/bar/"
+		base2.join("baz/", "..", "//data.txt")
+		XCTAssertEqual(base2, "/foo/bar/data.txt")
+	}
+	
+	func testJoinArray() {
+		var base1 = "/foo/bar"
+		base1.join(paths: ["/baz", "..", "/..//data.txt"])
+		XCTAssertEqual(base1, "/foo/data.txt")
+		
+		var base2 = "/foo/bar/"
+		base2.join(paths: ["baz/", "..", "//data.txt"])
+		XCTAssertEqual(base2, "/foo/bar/data.txt")
+	}
+	
+	func testJoiningVararg() {
+		let base1 = "/foo/bar"
+		XCTAssertEqual(base1.joining("/baz", "..", "/..//data.txt"), "/foo/data.txt")
+		
+		let base2 = "/foo/bar/"
+		XCTAssertEqual(base2.joining("baz/", "..", "//data.txt"), "/foo/bar/data.txt")
+	}
+	
+	func testJoiningArray() {
+		let base1 = "/foo/bar"
+		XCTAssertEqual(base1.joining(paths: ["/baz", "..", "/..//data.txt"]), "/foo/data.txt")
+		
+		let base2 = "/foo/bar/"
+		XCTAssertEqual(base2.joining(paths: ["baz/", "..", "//data.txt"]), "/foo/bar/data.txt")
+	}
+}


### PR DESCRIPTION
This PR is mostly additive. Nothing was explicitly removed, but `indexOf(_:)` was deprecated in favor of `index(of:)` which both has more options and is more in-line with Swift 3's naming scheme.

Other than that, you may want to check the `.xcodeproj` file, as that was changed. If you would like it to remain the way it was before, let me know and I'll revert it and make a new PR.