### PR TITLE
Change cocoapods name

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,11 @@ Then, regenerate your Xcode project:
 swift package generate-xcodeproj
 ```
 
+### Install via Cocoapods
+
+```ruby
+pod "String+Extensions"
+```
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # SwiftString
 
-[![Version](https://img.shields.io/cocoapods/v/SwiftString3.svg?style=flat)](http://cocoapods.org/pods/SwiftString3)
-[![License](https://img.shields.io/cocoapods/l/SwiftString3.svg?style=flat)](http://cocoapods.org/pods/SwiftString3)
-[![Platform](https://img.shields.io/cocoapods/p/SwiftString3.svg?style=flat)](http://cocoapods.org/pods/SwiftString3)
+[![Version](https://img.shields.io/cocoapods/v/String+Extensions.svg?style=flat)](http://cocoapods.org/pods/String+Extensions)
+[![License](https://img.shields.io/cocoapods/l/String+Extensions.svg?style=flat)](http://cocoapods.org/pods/String+Extensions)
+[![Platform](https://img.shields.io/cocoapods/p/String+Extensions.svg?style=flat)](http://cocoapods.org/pods/String+Extensions)
 ![Language](https://img.shields.io/badge/language-Swift%203.0-orange.svg)
 
 SwiftString is a lightweight string extension for Swift 3.

--- a/String+Extensions.podspec
+++ b/String+Extensions.podspec
@@ -1,5 +1,5 @@
 #
-# Be sure to run `pod lib lint SwiftString3.podspec' to ensure this is a
+# Be sure to run `pod lib lint String+Extensions.podspec' to ensure this is a
 # valid spec before submitting.
 #
 # Any lines starting with a # are optional, but their use is encouraged
@@ -7,12 +7,12 @@
 #
 
 Pod::Spec.new do |s|
-  s.name             = 'SwiftString3'
-  s.version          = '1.0.11'
+  s.name             = 'String+Extensions'
+  s.version          = '1.1.0'
   s.summary          = 'A lightweight string extension for Swift'
 
   s.description      = <<-DESC
-SwiftString is a lightweight string extension for Swift 3.
+String+Extensions is a lightweight string extension for Swift 3.
 This library was motivated by having to search StackOverflow for common string operations, and wanting them to be in one place with test coverage.
 
 Note the original client side Swift 2 repo can be found here: https://github.com/amayne/SwiftString


### PR DESCRIPTION
Cocoapods name was 'SwiftString3'.
It could be used for Swift3.
My mistake.