### PR TITLE
Fully reverted to stop error with package manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,5 @@ let package = Package(
     name: "SwiftString",
     targets: [],
     dependencies: [],
-	swiftLanguageVersions: [3],
     exclude: []
 )


### PR DESCRIPTION
'dependencies'
        swiftLanguageVersions: [3],
        ^~~~~~~~~~~~~~~~~~~~~~~~~~
        dependencies: []
Can't parse Package.swift manifest file because it contains invalid format. Fix Package.swift file format and try again.